### PR TITLE
フォーム入力のエラーメッセージ

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,10 +1,10 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
+  validates :user_name, presence: true, length: { maximum: 255 }
+  validates :email, presence: true, uniqueness: true
   validates :password, length: { in: 6..18 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
-  validates :user_name, presence: true, length: { maximum: 255 }
-  validates :email, presence: true, uniqueness: true
 
   has_many :posts, dependent: :destroy
   has_many :bookmarks, dependent: :destroy

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -2,6 +2,7 @@
   <div class="row">
     <div class="col-md-10 col-lg-5 mx-auto">
       <h1><%= t('posts.edit.title') %></h1>
+        <%= render 'shared/error_messages', object: @post %>
         <%= form_with model: @post, class: "new_post" do |f| %>
           <div class="mb-3">
             <%= f.label :post_type, class: "form-label" %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -2,6 +2,7 @@
   <div class="row">
     <div class="col-md-10 col-lg-5 mx-auto">
       <h1><%= t('posts.new.title') %></h1>
+        <%= render 'shared/error_messages', object: @post %>
         <%= form_with model: @post, class: "new_post" do |f| %>
           <div class="mb-3">
             <%= f.label :post_type, class: "form-label" %>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,9 @@
+<% if object.errors.any? %>
+  <div class="alert alert-danger">
+    <ul class="mb-0">
+      <% object.errors.each do |error| %>
+        <li><%= error.full_message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -2,6 +2,7 @@
   <div class="row">
     <div class="col-md-10 col-lg-5 mx-auto">
       <h1><%= t('users.edit.title') %></h1>
+        <%= render 'shared/error_messages', object: @user %>
         <%= form_with model: @user, class: "edit_user" do |f| %>
           <div class="mb-3">
             <%= f.label :user_name, class: "form-label" %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -2,6 +2,7 @@
   <div class="row">
     <div class="col-md-10 col-lg-5 mx-auto">
       <h1><%= t('users.new.title') %></h1>
+      <%= render 'shared/error_messages', object: @user %>
       <%= form_with model: @user do |f| %>
         <div class="mb-3">
           <%= f.label :user_name, class: "form-label" %>


### PR DESCRIPTION
### 実装概要
- フォーム入力時のエラー内容が分かるようにメッセージ出力を実装

### 編集詳細
- エラーメッセージ出力部分のパーシャルを作成
- ユーザー作成・編集、投稿作成・編集の計4個所のフォームにレンダリング
- users/new.html.erbのエラーメッセージ表示の際にメッセージの内容とフォームの順番が合うように、userモデルのバリデーション記述の順番を変更