### PR TITLE
集中モード実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,4 +7,9 @@ class ApplicationController < ActionController::Base
   def not_authenticated
     redirect_to login_path, danger: t("default.flash_message.require_login")
   end
+
+  def block_focus_mode
+    return unless current_user&.focus?
+    redirect_to user_path(current_user.id), danger: t("default.flash_message.mode_block"), status: :see_other
+  end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,12 @@
 class PostsController < ApplicationController
   skip_before_action :require_login, only: [ :index ]
+  before_action :block_focus_mode, only:[ :bookmarks ]
+
   def index
+    if current_user&.focus?
+      render :focus_mode
+      return
+    end
     @q = Post.includes(:user).where(post_type: :zenkou).ransack(params[:q])
     @posts = @q.result(distinct: true).order(created_at: :desc).page(params[:page])
   end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,6 @@
 class PostsController < ApplicationController
   skip_before_action :require_login, only: [ :index ]
-  before_action :block_focus_mode, only:[ :bookmarks ]
+  before_action :block_focus_mode, only: [ :bookmarks ]
 
   def index
     if current_user&.focus?

--- a/app/controllers/user_points_controller.rb
+++ b/app/controllers/user_points_controller.rb
@@ -1,5 +1,5 @@
 class UserPointsController < ApplicationController
-  before_action :block_focus_mode, only:[ :index ]
+  before_action :block_focus_mode, only: [ :index ]
 
   def index
     @user_points = UserPoint.includes(:user).order(total_points: :desc).limit(10)

--- a/app/controllers/user_points_controller.rb
+++ b/app/controllers/user_points_controller.rb
@@ -1,4 +1,6 @@
 class UserPointsController < ApplicationController
+  before_action :block_focus_mode, only:[ :index ]
+
   def index
     @user_points = UserPoint.includes(:user).order(total_points: :desc).limit(10)
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -48,6 +48,6 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:user_name, :email, :password, :password_confirmation, :terms_of_service)
+    params.require(:user).permit(:user_name, :email, :password, :password_confirmation, :terms_of_service, :mode)
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -5,6 +5,6 @@ class UserMailer < ApplicationMailer
     @user = User.find(user.id)
     @url  = edit_password_reset_url(@user.reset_password_token)
     mail(to: user.email,
-        subject: t("defaults.password_reset"))
+        subject: t("default.password_reset"))
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,8 @@ class User < ApplicationRecord
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
   validates :terms_of_service, acceptance: true, on: :create
   validates :reset_password_token, uniqueness: true, allow_nil: true
+  enum mode: { normal: 0, focus: 1 }
+
 
   has_many :posts, dependent: :destroy
   has_many :bookmarks, dependent: :destroy

--- a/app/views/posts/focus_mode.html.erb
+++ b/app/views/posts/focus_mode.html.erb
@@ -1,0 +1,14 @@
+<div class="container pt-3 text-center">
+  <h2 class="mb-3">現在「集中モード」利用中です</h2>
+  <p class="mb-4">他の人の投稿は表示しません。自分の記録に集中しましょう。</p>
+  <div class="">
+    <div class="py-2">
+      <%= link_to t('header.post_zenkou'), new_zenkou_posts_path, class: "btn btn-outline-warning me-2" %>
+      <%= link_to t('header.post_akugyou'), new_akugyou_posts_path, class: "btn btn-outline-warning" %>
+    </div>
+    <div>
+      <%= link_to t('header.my_page'), user_path(current_user), class: "btn btn-outline-warning me-2" %>
+      <%= link_to t('posts.focus.mode_change'), edit_user_path(current_user), class: "btn btn-outline-warning" %>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -15,9 +15,14 @@
             <%= t('header.how_to') %>
           </button>
         </li>
-        <li class="nav-item px-2">
-          <%= link_to t('header.ranking'), user_points_path, class: "nav-link" %>
-        </li>
+        <% unless current_user&.focus? %>
+          <li class="nav-item px-2">
+            <%= link_to t('header.ranking'), user_points_path, class: "nav-link" %>
+          </li>
+          <li class="nav-item px-2">
+            <%= link_to t('header.bookmarks'), bookmarks_posts_path, class: "nav-link" %>
+          </li>
+        <% end %>
         <li class="nav-item dropdown px-2">
             <%= link_to t('header.post'), '#', class: 'nav-link dropdown-toggle',data: {bs_toggle: 'dropdown'}, aria: {haspopup: 'true', expanded: 'false'} %>
           <ul class="dropdown-menu">
@@ -31,9 +36,6 @@
         </li>
         <li class="nav-item px-2">
           <%= link_to t('header.my_page'), user_path(current_user), class: "nav-link" %>
-        </li>
-        <li class="nav-item px-2">
-          <%= link_to t('header.bookmarks'), bookmarks_posts_path, class: "nav-link" %>
         </li>
         <li class="nav-item px-2">
           <%= button_to t('header.logout'), logout_path, method: :delete, class: "nav-link" %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -9,6 +9,11 @@
             <%= f.text_field :user_name, class: "form-control" %>
           </div>
           <div class="mb-3">
+            <%= f.label :mode, class: "form-label" %>
+            <%= f.select :mode, [["通常モード", "normal"], ["集中モード", "focus"]], class: "form-select" %>
+            <p>※集中モードは他のユーザーの投稿が見えなくなるモードです。自分の投稿は他ユーザーに公開されていますので、投稿内容には引き続きご注意ください。</p>          
+          </div>
+          <div class="mb-3">
             <%= f.label :email, class: "form-label" %>
             <%= f.email_field :email, class: "form-control" %>
           </div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -10,6 +10,7 @@ ja:
         user_name: ユーザーネーム
         password: パスワード
         password_confirmation: パスワード確認
+        mode: モード選択
       post:
         body: 本文
         post_type: 種類

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -17,6 +17,7 @@ ja:
       not_created: "%{item}の作成に失敗しました"
       deleted: "%{item}を削除しました"
       require_login: ログインしてください
+      mode_block: 集中モードのため表示できないページです
     search:
       word: 本文
       period_start: 投稿期間（開始）
@@ -32,7 +33,10 @@ ja:
       myouou: 明王
       bosatsu: 菩薩
       daibutu: 大仏
-    passwore_reset: パスワードの変更について
+    password_reset: パスワードの変更について
+    mode:
+      normal: 通常モード
+      focus: 集中モード
   user_sessions:
     create:
       success: ログインしました
@@ -53,6 +57,7 @@ ja:
       title: ユーザー編集
       update: 更新
       delete: アカウント削除
+      mode: モード選択
     show:
       title: マイページ
       user_rank: ユーザーランク
@@ -87,6 +92,8 @@ ja:
       title: 投稿を編集
       update: 更新
       delete: 削除
+    focus:
+      mode_change: 通常モードに変更する
   user_points:
     index:
       user_rank: ユーザーランク

--- a/db/migrate/20250828062446_add_mode_to_users.rb
+++ b/db/migrate/20250828062446_add_mode_to_users.rb
@@ -1,0 +1,6 @@
+class AddModeToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :mode, :integer, null: false, default: 0
+    add_index :users, :mode
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_25_074218) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_28_062446) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -55,7 +55,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_25_074218) do
     t.datetime "reset_password_token_expires_at"
     t.datetime "reset_password_email_sent_at"
     t.integer "access_count_to_reset_password_page", default: 0
+    t.integer "mode", default: 0, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["mode"], name: "index_users_on_mode"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 


### PR DESCRIPTION
### 実装概要
- ユーザーが他ユーザーの投稿を見れない集中モードの実装
  - ランキングページ・ブックマーク一覧ページのアクセス拒否
  - ルートページを投稿がない静的ページが表示される

### 編集詳細
- Usersテーブルにmodeカラムを追加
- application_controllerにログインユーザーのmodeを確認し、表示を拒否するメソッドを作成
- posts_controller,user_points_controllerにbefore_actionを追加
- Userモデルでenumを追加
- users_controllerのストロングパラメーターを編集
- _header.html.erbを集中モードにも対応したデザインに変更
- focus_mode.html.erbというパーシャルを作成