### PR TITLE
管理者用ログイン実装

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,0 +1,15 @@
+class Admin::BaseController < ApplicationController
+  before_action :check_admin
+  layout 'admin/layouts/application'
+
+  private
+
+  def not_authenticated
+    flash[:warning] = t('defaults.flash_message.require_login')
+    redirect_to admin_login_path
+  end
+
+  def check_admin
+    redirect_to root_path, danger: t('defaults.flash_message.not_authorized') unless current_user.admin?
+  end
+end

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,15 +1,15 @@
 class Admin::BaseController < ApplicationController
   before_action :check_admin
-  layout 'admin/layouts/application'
+  layout "admin/layouts/application"
 
   private
 
   def not_authenticated
-    flash[:warning] = t('defaults.flash_message.require_login')
+    flash[:warning] = t("defaults.flash_message.require_login")
     redirect_to admin_login_path
   end
 
   def check_admin
-    redirect_to root_path, danger: t('defaults.flash_message.not_authorized') unless current_user.admin?
+    redirect_to root_path, danger: t("defaults.flash_message.not_authorized") unless current_user.admin?
   end
 end

--- a/app/controllers/admin/posts_controller.rb
+++ b/app/controllers/admin/posts_controller.rb
@@ -1,0 +1,5 @@
+class Admin::PostsController < Admin::BaseController
+  def index
+    @posts = Post.includes(:user).order(created_at: :desc).page(params[:page])
+  end
+end

--- a/app/controllers/admin/user_sessions_controller.rb
+++ b/app/controllers/admin/user_sessions_controller.rb
@@ -1,0 +1,22 @@
+class Admin::UserSessionsController < Admin::BaseController
+  skip_before_action :require_login, only: %i[new create]
+  skip_before_action :check_admin, only: %i[new create]
+  layout 'layouts/admin_login'
+
+  def new; end
+
+  def create
+    @user = login(params[:email], params[:password])
+    if @user
+      redirect_to admin_root_path, success: t('.success')
+    else
+      flash.now[:danger] = t('.failure')
+      render :new
+    end
+  end
+
+  def destroy
+    logout
+    redirect_to admin_login_path, status: :see_other, danger: t('.success')
+  end
+end

--- a/app/controllers/admin/user_sessions_controller.rb
+++ b/app/controllers/admin/user_sessions_controller.rb
@@ -1,22 +1,22 @@
 class Admin::UserSessionsController < Admin::BaseController
   skip_before_action :require_login, only: %i[new create]
   skip_before_action :check_admin, only: %i[new create]
-  layout 'layouts/admin_login'
+  layout "layouts/admin_login"
 
   def new; end
 
   def create
     @user = login(params[:email], params[:password])
     if @user
-      redirect_to admin_root_path, success: t('.success')
+      redirect_to admin_root_path, success: t(".success")
     else
-      flash.now[:danger] = t('.failure')
-      render :new
+      flash.now[:danger] = t(".failed")
+      render :new, status: :unprocessable_entity
     end
   end
 
   def destroy
     logout
-    redirect_to admin_login_path, status: :see_other, danger: t('.success')
+    redirect_to admin_login_path, status: :see_other, danger: t(".success")
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,8 +1,8 @@
 module ApplicationHelper
   def default_meta_tags
     {
-      site: "善行貯金",
-      title: "~日常を見直す習慣管理アプリ~",
+      site: "~日常を見直す習慣管理アプリ~",
+      title: "善行貯金",
       reverse: true,
       separator: "|",
       description: "「良いこと」を貯めて、良いことをできなかったときの自分を許しやすくするサービス",
@@ -14,8 +14,8 @@ module ApplicationHelper
         { href: image_url("apple-touch-icon.png"), rel: "apple-touch-icon", sizes: "180x180" }
       ],
       og: {
-        site_name: "善行貯金",
-        title: "~日常を見直す習慣管理アプリ~",
+        site_name: "~日常を見直す習慣管理アプリ~",
+        title: "善行貯金",
         description: "「良いこと」を貯めて、良いことをできなかったときの自分を許しやすくするサービス",
         type: "website",
         url: request.original_url,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,7 @@ class User < ApplicationRecord
   validates :terms_of_service, acceptance: true, on: :create
   validates :reset_password_token, uniqueness: true, allow_nil: true
   enum mode: { normal: 0, focus: 1 }
+  enum role: { general: 0, admin: 1 }
 
 
   has_many :posts, dependent: :destroy

--- a/app/views/admin/layouts/application.html.erb
+++ b/app/views/admin/layouts/application.html.erb
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title><%= "管理画面" || "善行貯金" %></title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <link rel="stylesheet "href="https://cdn.jsdelivr.net/npm/admin-lte@4.0.0-rc3/dist/css/adminlte.min.css" crossorigin="anonymous"/>
+    <%= javascript_importmap_tags %>
+    <%= display_meta_tags(default_meta_tags) %>
+  </head>
+  <body class="d-flex flex-column min-vh-100">
+    <div class="app-wrapper">
+      <%= render 'admin/shared/header' %>
+      <%= render 'admin/shared/sidebar' %>
+      <div class="row">
+        <main class="app-main col-md-9 ms-sm-auto col-lg-10">
+
+          <% flash.each do |message_type, message| %>
+            <div class="alert alert-<%= message_type %>">
+              <%= message %>
+            </div>
+          <% end %>
+
+          <%= yield %>
+        </main>
+      </div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/admin-lte@4.0.0-rc3/dist/js/adminlte.min.js" crossorigin="anonymous" ></script>
+  </body>
+</html>

--- a/app/views/admin/posts/index.html.erb
+++ b/app/views/admin/posts/index.html.erb
@@ -1,0 +1,47 @@
+<div class="row justify-content-center">
+  <div class="col-12 col-lg-10 col-xl-8">
+    <div class="card">
+        <div class="card-header d-flex align-items-center">
+        <h3 class="card-title mb-0">投稿一覧</h3>
+        </div>
+
+        <div class="card-body p-0">
+        <div class="table-responsive">
+            <table class="table table-striped table-bordered align-middle mb-0">
+            <thead class="table-light">
+                <tr>
+                <th>本文（body）</th>
+                <th class="text-center">善行ポイント</th>
+                <th>作成ユーザー</th>
+                <th><%= t("users.show.edit_destroy") %></th>
+                </tr>
+            </thead>
+            <tbody>
+                <% @posts.each do |post| %>
+                <tr>
+                    <td class="text-truncate" style="max-width: 300px;"><%= post.body %></td>
+                    <td class="text-center">
+                    <span class="badge text-bg-secondary"><%= post.point %></span>
+                    </td>
+                    <td><%= post.user.user_name %></td>
+                    <td>
+                    <%= link_to edit_post_path(post), id: "button-edit-#{post.id}" do %>
+                        <i class="bi bi-pencil-fill"></i>
+                    <% end %>
+                    <%= link_to post_path(post), id: "button-delete-#{post.id}", data: { turbo_method: :delete, turbo_confirm: t('default.delete_confirm') } do %>
+                        <i class="bi bi-trash-fill"></i>
+                    <% end %>
+                    </td>
+                </tr>
+                <% end %>
+            </tbody>
+            </table>
+        </div>
+        </div>
+
+        <div class="card-footer">
+        <%= paginate @posts, theme: 'bootstrap-5' %>
+        </div>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/shared/_header.html.erb
+++ b/app/views/admin/shared/_header.html.erb
@@ -1,0 +1,19 @@
+<header>
+  <nav class="app-header px-4">
+    <nav class="navbar navbar-expand-lg navbar-light">
+      <div class="mf-auto">
+        <%= image_tag 'main_image.png', width: 153 %>
+        <span class="ms-2 lead fw-bold">
+          ~管理画面~
+        </span>
+      </div>
+      <div class="ms-auto fw-bold">
+        <ul class="navbar-nav" style="flex-direction: row;">
+          <li class="nav-item px-2">
+            <%= button_to t('header.logout'), admin_logout_path, method: :delete, class: "nav-link" %>
+          </li>
+        </ul>
+      </div>
+    </nav>
+  </nav>
+</header>

--- a/app/views/admin/shared/_sidebar.html.erb
+++ b/app/views/admin/shared/_sidebar.html.erb
@@ -1,0 +1,14 @@
+<aside class="app-sidebar bg-body-secondary">
+  <div class="sidebar-wrapper">
+    <nav class="mx-2">
+      <ul class="nav sidebar-menu flex-column">
+        <li class="nav-item">
+          <p>投稿一覧</p>
+        </li>
+        <li class="nav-item">
+          <p>名言一覧</p>
+        </li>
+      </ul>
+    </nav>
+  </div>
+</aside>

--- a/app/views/admin/user_sessions/new.html.erb
+++ b/app/views/admin/user_sessions/new.html.erb
@@ -1,0 +1,20 @@
+<div class="container">
+  <div class="row">
+    <div class=" col-md-10 col-lg-5 mx-auto">
+      <h1><%= t("admin_login.title") %></h1>
+      <%= form_with url: admin_login_path do |f| %>
+        <div class="mb-3">
+          <%= f.label :email %>
+          <%= f.email_field :email, class: "form-control" %>
+        </div>
+        <div class="mb-3">
+          <%= f.label :password %>
+          <%= f.password_field :password, class: "form-control" %>
+        </div>
+        <div class="d-flex flex-column w-75 mx-auto gap-2">
+          <%= f.submit t('user_sessions.new.login'), class: "btn btn-primary" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/admin_login.html.erb
+++ b/app/views/layouts/admin_login.html.erb
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title><%= "管理画面" || "善行貯金" %></title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+    <link rel="manifest" href="/manifest.json">
+    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <link rel="stylesheet "href="https://cdn.jsdelivr.net/npm/admin-lte@4.0.0-rc3/dist/css/adminlte.min.css" crossorigin="anonymous"/>
+    <%= javascript_importmap_tags %>
+    <%= display_meta_tags(default_meta_tags) %>
+  </head>
+  <body>
+    <% flash.each do |message_type, message| %>
+      <div class="alert alert-<%= message_type %>">
+          <%= message %>
+      </div>
+    <% end %>
+    <%= yield %>
+  </body>
+</html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= content_for(:title) || "善行貯金" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -18,6 +18,7 @@ ja:
       deleted: "%{item}を削除しました"
       require_login: ログインしてください
       mode_block: 集中モードのため表示できないページです
+      not_authorized: 管理者限定のため利用不可です
     search:
       word: 本文
       period_start: 投稿期間（開始）
@@ -112,3 +113,12 @@ ja:
     edit:
       title: パスワード変更
       submit: 変更
+  admin_login:
+    title: 管理者ログイン
+  admin:
+    user_sessions:
+      create:
+        success: 管理者としてログインしました
+        failed: ログインに失敗しました
+      destroy:
+        success: ログアウトしました

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,4 +27,12 @@ Rails.application.routes.draw do
   delete "logout", to: "user_sessions#destroy"
   resources :user_points, only: %i[index]
   resources :password_resets, only: %i[new create edit update]
+
+  namespace :admin do
+    root "posts#index"
+    resource :posts, only: %i[index]
+    get "login" => "user_sessions#new", :as => :login
+    post "login" => "user_sessions#create"
+    delete "logout" => "ser_sessions#destroy", :as => :logout
+  end
 end

--- a/db/migrate/20250830060818_add_role_to_users.rb
+++ b/db/migrate/20250830060818_add_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :role, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_28_062446) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_30_060818) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -56,6 +56,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_28_062446) do
     t.datetime "reset_password_email_sent_at"
     t.integer "access_count_to_reset_password_page", default: 0
     t.integer "mode", default: 0, null: false
+    t.integer "role", default: 0, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["mode"], name: "index_users_on_mode"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "^8.0.13",
     "@popperjs/core": "^2.11.8",
+    "admin-lte": "4.0.0-rc3",
     "autoprefixer": "^10.4.21",
     "bootstrap": "^5.3.6",
     "bootstrap-icons": "^1.13.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -244,6 +244,11 @@
   resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-7.2.201.tgz#bfb3da01b3e2462f5a18f372c52dedd7de76037f"
   integrity sha512-wsTdWoZ5EfG5k3t7ORdyQF0ZmDEgN4aVPCanHAiNEwCROqibSZMXXmCbH7IDJUVri4FOeAVwwbPINI7HVHPKBw==
 
+admin-lte@4.0.0-rc3:
+  version "4.0.0-rc3"
+  resolved "https://registry.yarnpkg.com/admin-lte/-/admin-lte-4.0.0-rc3.tgz#508ad63d5fb3a3fe50434146a9204c4e309fdd2b"
+  integrity sha512-BKEGJknLiNW/l++6tjO9YIy2x6il4y/S977cSaRfi+wadZF3xe7U+vDR8q2H99CVC49VmPqRwb36hiyEVmBQTw==
+
 ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"


### PR DESCRIPTION
### 実装概要
- User.roleがadminのアカウントのみ管理者機能を実行できるように実装
- 管理者アカウントとしてログインできる機能を実装

### 編集詳細
- UsersテーブルにRoleカラムを追加
- 管理者用のビューを作成
  - views/layouts/admin_login.html.erb
  - views/admin/layouts/application.html.erb
  - views/admin/shared/_header.html.erb
  - views/admin/shared/_sidebar.html.erb
  - views/admin/posts/index.html.erb
  - views/admin/user_sessions/new.html.erb
- 管理者用のコントローラーを作成
  - app/controllers/admin/base_controller.rb
  - app/controllers/admin/user_sessions_controller.rb
  - app/controllers/admin/posts_controller.rb
- ルーティングの追加
- i18n対応語彙追加