### PR TITLE
独自ドメインの取得とアナリティクス

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,16 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-577CZDG55C"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-577CZDG55C');
+    </script>
+
     <%= yield :head %>
 
     <link rel="manifest" href="/manifest.json">

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -109,6 +109,7 @@ Rails.application.configure do
   config.active_record.attributes_for_inspect = [ :id ]
 
   # Enable DNS rebinding protection and other `Host` header attacks.
+  config.hosts << 'www.zenkouchokin.com'
   # config.hosts = [
   #   "example.com",     # Allow requests from example.com
   #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -109,7 +109,7 @@ Rails.application.configure do
   config.active_record.attributes_for_inspect = [ :id ]
 
   # Enable DNS rebinding protection and other `Host` header attacks.
-  config.hosts << 'www.zenkouchokin.com'
+  config.hosts << "www.zenkouchokin.com"
   # config.hosts = [
   #   "example.com",     # Allow requests from example.com
   #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -117,7 +117,7 @@ Rails.application.config.sorcery.configure do |config|
   #
   config.twitter.key = ENV["TWITTER_API_KEY"]
   config.twitter.secret = ENV["TWITTER_API_SECRET"]
-  config.twitter.callback_url = "https://zenkouchokin-app.onrender.com/oauth/callback?provider=twitter"
+  config.twitter.callback_url = "https://zenkouchokin.com/oauth/callback?provider=twitter"
   config.twitter.user_info_mapping = {
     user_name: "screen_name"
   }


### PR DESCRIPTION
### 実装概要
- Render初期設定ドメインから独自ドメインに変更
- Googleアナリティクスの適応

### 編集詳細
- 記述を独自ドメインに適応したものに変更
  - config/environments/production.html.erb
  - config/initializers/sorcery.rb
- Googleアナリティクス用タグを追加
  - app/views/layouts/application.html.erb